### PR TITLE
Change tuple syntax from bananas to parentheses

### DIFF
--- a/docs/concrete/README.md
+++ b/docs/concrete/README.md
@@ -122,5 +122,5 @@ The constructs available for the abstract syntax:
   abstract syntax, as list literals (e.g. `[1, 2, 3]`) or using the
   cons list constructor (e.g. `Hd::Tl`).
 * Tuples:  Tuples can be written in terms, as they can be written in
-  the abstract syntax as a comma-separated list between bananas
-  (e.g. `(|1, 2, 3|)`).
+  the abstract syntax as a comma-separated list between parentheses
+  (e.g. `(1, 2, 3)`).

--- a/docs/main/README.md
+++ b/docs/main/README.md
@@ -71,7 +71,7 @@ We have some other simple expressions:
 * Let bindings, written `Let <var> := <bound> In <body>`, bind the
   result of `<bound>` to the variable `<var>` for use in `<body>`.
   This can bind multiple variables if the bound expression is a tuple,
-  such as `Let A, B, C := (|1, 2, 3|) In A + B + C`, which will give a
+  such as `Let A, B, C := (1, 2, 3) In A + B + C`, which will give a
   result of 6.  All bound variables must be capitalized.
 * Variables, which may refer to arguments to the function or variables
   bound by a let binding
@@ -98,7 +98,7 @@ Parse <nonterminal> from <string>
 ```
 where `<nonterminal>` is a concrete nonterminal name and `<string>` is
 an expression of type `string`.  A parsing expression produces a
-three-tuple of type `(|bool, <abstract syntax>, string|)`.  The
+three-tuple of type `(bool, <abstract syntax>, string)`.  The
 members of the tuple are as follows:
 * `bool`:  Whether the parse was successful (`true`) or not.
 * `<abstract syntax>`:  The abstract syntax produced from the parsed
@@ -146,5 +146,5 @@ whether the derivation was successful or not.  The remaining elements
 in the tuple are the terms found for the output variables, which are
 only defined if the derivation was successful (the first element of
 the tuple is `true`).  In the example above, the derivation expression
-has type `(|bool, ty|)` where `ty` is a user-defined syntactic
+has type `(bool, ty)` where `ty` is a user-defined syntactic
 category.

--- a/docs/semantic/judgments.md
+++ b/docs/semantic/judgments.md
@@ -25,10 +25,8 @@ rules, a variable can be unified with any term.
 We also have terms building our built-in types:
 * Numeric constants build the integer (`int`) type.
 * Double-quoted strings build the string type.
-* Tuples are written as comma-separated lists of terms inside bananas,
-  such as `(|1, 2, "x"|)`.  We use bananas rather than simple
-  parentheses because of a parsing conflict with constructor
-  application.
+* Tuples are written as comma-separated lists of terms inside parentheses,
+  such as `(1, 2, "x")`.
 * Lists of constant length can be written in square brackets, such as
   `[1, 2, 3, 4]`.  Lists can also be written using cons notation, such
   as `1::2::Rest`, specifying a list where the first two elements are
@@ -36,8 +34,8 @@ We also have terms building our built-in types:
   anything.
 
 Finally, we have one last type of term, an ascription, written as
-`(|<term> : <type>|)`, asserting the term has the given type
-(e.g. `(|3 : int|)`).  Sometimes it is difficult to understand why a
+`(<term> : <type>)`, asserting the term has the given type
+(e.g. `(3 : int)`).  Sometimes it is difficult to understand why a
 rule is ill-typed, and asserting the types of variables or larger
 terms in strategic places can improve the type error messages given.
 Other than possibly improving the error messages from typing, an
@@ -142,7 +140,7 @@ The primary component can be thought of as what the judgment is
 so we would choose the expression as the primary component.  We might
 declare our typing relation thus:
 ```
-Judgment typeOf : [(|string, ty|)] expr* ty
+Judgment typeOf : [(string, ty)] expr* ty
 ```
 The `*` marks the expression as the primary component.
 

--- a/docs/semantic/syntax.md
+++ b/docs/semantic/syntax.md
@@ -61,7 +61,7 @@ We also have two built-in type constructors that can contain any
 types, lists and tuples:
 * The list type is written with the inner type in square brackets,
   such as `[int]`, which is a list of integers.
-* Tuples are written as comma-separated lists in bananas, such as
-  `(|int, string|)`, which is a pair of an integer and a string.  As
-  another example, we could also have `(|int, expr, [int]|)`, a triple
+* Tuples are written as comma-separated lists in parentheses, such as
+  `(int, string)`, which is a pair of an integer and a string.  As
+  another example, we could also have `(int, expr, [int])`, a triple
   of an integer, an expression, and a list of integers.

--- a/examples/functions/host/domains.sos
+++ b/examples/functions/host/domains.sos
@@ -1,25 +1,12 @@
 Module functions:host
 
-/*Domain for Type Contexts*/
-Fixed Judgment domain : [(|A, B|)] [A]
-
-============ [D-Empty]
-domain [] []
-
-
-domain Rest RestDomain
-==================================== [D-Add]
-domain (|S, Ty|)::Rest S::RestDomain
-
-
-
 /*Equality for Type Contexts*/
-Fixed Judgment tyctx_eq : [(|string, ty|)] [(|string, ty|)]
+Fixed Judgment tyctx_eq : [(string, ty)] [(string, ty)]
 
 
 
 /*Equality for Evaluation Contexts*/
-Fixed Judgment evalctx_eq : [(|string, value|)] [(|string, value|)]
+Fixed Judgment evalctx_eq : [(string, value)] [(string, value)]
 
 /*TODO write rules for these
   Probably take the domains and make sure they have the same names,

--- a/examples/functions/host/eval.sos
+++ b/examples/functions/host/eval.sos
@@ -50,12 +50,12 @@ appendOutput O1 addOutput(O2, V) addOutput(O3, V)
 
 
 /*Expressions need output, functx because of function calls*/
-Judgment eval_e : functx [(|string, value|)] e* value output
-Judgment eval_rf : functx [(|string, value|)] recFieldExprs* [(|string, value|)] output
+Judgment eval_e : functx [(string, value)] e* value output
+Judgment eval_rf : functx [(string, value)] recFieldExprs* [(string, value)] output
 /*given arguments and names, produce an eval ctx for the function*/
-Judgment eval_args : functx [(|string, value|)] args* [string] [(|string, value|)] output
+Judgment eval_args : functx [(string, value)] args* [string] [(string, value)] output
 /*Statements produce a new eval ctx and some output*/
-Judgment eval_c : functx [(|string, value|)] c* [(|string, value|)] output
+Judgment eval_c : functx [(string, value)] c* [(string, value)] output
 /*get the evaluation information from a function
   (name, return name, parameter names, body)*/
 Judgment eval_fun : fun* string string [string] c
@@ -192,8 +192,8 @@ eval_rf FG G endRecFieldExprs [] emptyOutput
 eval_e FG G E V O1
 eval_rf FG G Rest FVs O2
 appendOutput O1 O2 O
---------------------------------------------------------- [ERF-Add]
-eval_rf FG G addRecFieldExprs(L, E, Rest) (|L, V|)::FVs O
+------------------------------------------------------- [ERF-Add]
+eval_rf FG G addRecFieldExprs(L, E, Rest) (L, V)::FVs O
 
 
 
@@ -206,8 +206,8 @@ eval_args FG G endArgs [] [] emptyOutput
 eval_e FG G E V O1
 eval_args FG G Rest NRest C O2
 appendOutput O1 O2 O
------------------------------------------------------- [EA-Add]
-eval_args FG G addArgs(E, Rest) X::NRest (|X, V|)::C O
+---------------------------------------------------- [EA-Add]
+eval_args FG G addArgs(E, Rest) X::NRest (X, V)::C O
 
 
 
@@ -225,13 +225,13 @@ eval_c FG G seq(C1, C2) G2 O
 
 
 eval_e FG G E V O
-------------------------------------------- [E-Declare]
-eval_c FG G declare(X, Ty, E) (|X, V|)::G O
+----------------------------------------- [E-Declare]
+eval_c FG G declare(X, Ty, E) (X, V)::G O
 
 
 eval_e FG G E V O
--------------------------------------- [E-Assign]
-eval_c FG G assign(X, E) (|X, V|)::G O
+------------------------------------ [E-Assign]
+eval_c FG G assign(X, E) (X, V)::G O
 
 
 eval_e FG G Cond trueVal O1
@@ -277,25 +277,26 @@ eval_c FG G printVal(E) G addOutput(O, V)
 /*Update the associations in the first tyCtx for the fields,
   descending through it to place the value in the final one, producing
   the ending tyCtx*/
-Judgment update_rec_fields : recFields* [(|string, value|)] value [(|string, value|)]
+Judgment update_rec_fields : recFields* [(string, value)] value [(string, value)]
 
 --------------------------------------------------- [URF-One]
-update_rec_fields oneField(F) Init V (|F, V|)::Init
+update_rec_fields oneField(F) Init V (F, V)::Init
 
 
 lookup Init F recVal(FFields)
 update_rec_fields Rest FFields V UpdatedFFields
----------------------------------------------------- [URF-Step]
-update_rec_fields addField(F, Rest) Init V (|
-                   F, recVal(UpdatedFFields)|)::Init
+----------------------------------------------------- [URF-Step]
+{update_rec_fields addField(F, Rest) Init V
+                   (F, recVal(UpdatedFFields))::Init}
 
 
 
 /*Program Evaluation*/
 
 eval_fun Fun Name RetName Names Body
-eval_program MainArgs addFun(Name, RetName, Names, Body, FG) Rest O
-------------------------------------------------------------- [EP-Add]
+{eval_program MainArgs addFun(Name, RetName, Names,
+                              Body, FG) Rest O}
+--------------------------------------------------- [EP-Add]
 eval_program ManArgs FG addProgram(Fun, Rest) O
 
 
@@ -319,15 +320,15 @@ full_eval Args P O
 
 
 /*Turn a list of names and a list of values into an evalctx*/
-Fixed Judgment buildEvalctx : [string] [value] [(|string, value|)]
+Fixed Judgment buildEvalctx : [string] [value] [(string, value)]
 
 ===================== [BEC-End]
 buildEvalctx [] [] []
 
 
 buildEvalctx PRest VRest ERest
-============================================== [BEC-Add]
-buildEvalctx N::PRest V::VRest (|N, V|)::ERest
+============================================ [BEC-Add]
+buildEvalctx N::PRest V::VRest (N, V)::ERest
 
 
 

--- a/examples/functions/host/syntax.sos
+++ b/examples/functions/host/syntax.sos
@@ -59,7 +59,7 @@ Translation program :
 /*Types*/
 ty ::= intTy
      | boolTy
-     | recTy([(|string, ty|)])
+     | recTy([(string, ty)])
 Translation ty :
 
 
@@ -67,6 +67,6 @@ Translation ty :
 value ::= intVal(int)
         | trueVal
         | falseVal
-        | recVal([(|string, value|)])
+        | recVal([(string, value)])
 Translation value :
 

--- a/examples/functions/host/typing.sos
+++ b/examples/functions/host/typing.sos
@@ -32,14 +32,14 @@ paramsToTyList addParams(X, Ty, Rest) Ty::TyRest
 
 
 /*Expressions*/
-Judgment typeOf : funtyctx [(|string, ty|)] e* ty
-Judgment typeRecFields : funtyctx [(|string, ty|)] recFieldExprs* [(|string, ty|)]
+Judgment typeOf : funtyctx [(string, ty)] e* ty
+Judgment typeRecFields : funtyctx [(string, ty)] recFieldExprs* [(string, ty)]
 /*Statements*/
-Judgment typeOK : funtyctx [(|string, ty|)] c* [(|string, ty|)]
-Judgment typeArgs : funtyctx [(|string, ty|)] args* [ty]
+Judgment typeOK : funtyctx [(string, ty)] c* [(string, ty)]
+Judgment typeArgs : funtyctx [(string, ty)] args* [ty]
 /*Functions*/
 Judgment funTyOK : funtyctx fun*
-Judgment paramsToTyCtx : params* [(|string, ty|)]
+Judgment paramsToTyCtx : params* [(string, ty)]
 /*Program*/
 Judgment programTyOK : funtyctx  program*
 Judgment buildFunTyCtx : program* funtyctx
@@ -124,8 +124,8 @@ typeRecFields FG G endRecFieldExprs []
 typeOf FG G E Ty
 typeRecFields FG G Rest FTys
 no_lookup FTys L /*each label only occurs once*/
------------------------------------------------------------- [TRF-Add]
-typeRecFields FG G addRecFieldExprs(L, E, Rest) (|L, Ty|)::FTys
+------------------------------------------------------------- [TRF-Add]
+typeRecFields FG G addRecFieldExprs(L, E, Rest) (L, Ty)::FTys
 
 
 
@@ -156,8 +156,8 @@ typeOK FG G seq(C1, C2) G2
 
 no_lookup G X /*can't overwrite existing decls*/
 typeOf FG G E Ty
------------------------------------------- [T-Declare]
-typeOK FG G declare(X, Ty, E) (|X, Ty|)::G
+---------------------------------------- [T-Declare]
+typeOK FG G declare(X, Ty, E) (X, Ty)::G
 
 
 typeOf FG G E Ty
@@ -196,7 +196,7 @@ typeOK FG G printVal(E) G
 
 /*Check whether the update to the nested fields is valid
   The tyctx is the fields of the record*/
-Judgment checkRecUpdate : recFields* [(|string, ty|)] ty
+Judgment checkRecUpdate : recFields* [(string, ty)] ty
 
 lookup RecFieldTys F Ty
 ----------------------------------------- [CRU-OneField]
@@ -213,7 +213,7 @@ checkRecUpdate addField(F, Rest) RecFieldTys Ty
 /*Function Typing*/
 
 paramsToTyCtx Params G
-typeOK FG (|RetName, RetTy|)::G Body G2 /*ret name declared*/
+typeOK FG (RetName, RetTy)::G Body G2 /*ret name declared*/
 -------------------------------------------------- [T-Fun]
 funTyOK FG fun(Name, RetTy, RetName, Params, Body)
 
@@ -224,7 +224,7 @@ paramsToTyCtx endParams []
 
 paramsToTyCtx Rest TRest
 ----------------------------------------------------- [PtTC-Add]
-paramsToTyCtx addParams(X, Ty, Rest) (|X, Ty|)::TRest
+paramsToTyCtx addParams(X, Ty, Rest) (X, Ty)::TRest
 
 
 
@@ -292,7 +292,7 @@ typeOfVal recVal(Fields) recTy(FTys)
 
 /*Typing for evaluation contexts to allow type soundness and recVal
   typing*/
-Fixed Judgment typeOfEvalctx : [(|string, value|)] [(|string, ty|)]
+Fixed Judgment typeOfEvalctx : [(string, value)] [(string, ty)]
 
 =================== [TEC-Empty]
 typeOfEvalctx [] []
@@ -300,6 +300,6 @@ typeOfEvalctx [] []
 
 typeOfVal V Ty
 typeOfEvalctx Rest RestTys
-=============================================== [TEC-Add]
-typeOfEvalctx (|X, V|)::Rest (|X, Ty|)::RestTys
+=========================================== [TEC-Add]
+typeOfEvalctx (X, V)::Rest (X, Ty)::RestTys
 

--- a/examples/functions/list/list.sos
+++ b/examples/functions/list/list.sos
@@ -78,10 +78,10 @@ ty ::= ...
 /*Strictly speaking, an empty list doesn't have the head or tail
   fields.  However, we don't have any translation constraints, so we
   can do whatever we want, and this is close.*/
------------------------------------------------------- [Trans-ListTy]
+----------------------------------------------- [Trans-ListTy]
 |{ty}- listTy(T) ~~>
-       recTy([(|"head", T|), (|"tail", listTy(T)|),
-              (|"null", boolTy|)])
+       recTy([("head", T), ("tail", listTy(T)),
+              ("null", boolTy)])
 
 
 
@@ -91,11 +91,11 @@ value ::= ...
         | consVal(value, value)
 
 
--------------------------------------------------- [Trans-NilVal]
-|{value}- nilVal ~~> recVal([(|"null", trueVal|)])
+------------------------------------------------ [Trans-NilVal]
+|{value}- nilVal ~~> recVal([("null", trueVal)])
 
 
-------------------------------------------------- [Trans-ConsVal]
+--------------------------------------------- [Trans-ConsVal]
 |{value}- consVal(Hd, Tl) ~~>
-          recVal([(|"head", Hd|), (|"tail", Tl|),
-                  (|"null", falseVal|)])
+          recVal([("head", Hd), ("tail", Tl),
+                  ("null", falseVal)])

--- a/examples/functions/security/analysis.sos
+++ b/examples/functions/security/analysis.sos
@@ -60,14 +60,14 @@ join S private private
 
 
 /*Expressions*/
-Judgment level : seclevel funsecctx [(|string, seclevel|)] e* seclevel
-Judgment rf_level : seclevel funsecctx [(|string, seclevel|)] recFieldExprs* seclevel
-Judgment level_args : seclevel funsecctx [(|string, seclevel|)] args* [seclevel]
+Judgment level : seclevel funsecctx [(string, seclevel)] e* seclevel
+Judgment rf_level : seclevel funsecctx [(string, seclevel)] recFieldExprs* seclevel
+Judgment level_args : seclevel funsecctx [(string, seclevel)] args* [seclevel]
 /*Statements*/
-Judgment secure : seclevel funsecctx [(|string, seclevel|)] c* [(|string, seclevel|)]
+Judgment secure : seclevel funsecctx [(string, seclevel)] c* [(string, seclevel)]
 /*Functions*/
 Judgment secure_fun : funsecctx fun*
-Judgment paramsToSecCtx : params* [(|string, seclevel|)]
+Judgment paramsToSecCtx : params* [(string, seclevel)]
 /*Program*/
 Judgment secure_program : funsecctx program*
 Judgment buildFunSecCtx : program* funsecctx
@@ -215,20 +215,20 @@ secure PC FG G seq(C1, C2) G2
 
 
 level PC FG G E public
-------------------------------------------------- [S-Declare]
-secure PC FG G declare(X, Ty, E) (|X, public|)::G
+----------------------------------------------- [S-Declare]
+secure PC FG G declare(X, Ty, E) (X, public)::G
 
 
 level PC FG G E S
-------------------------------------------- [S-DeclareSecPrivate]
-secure PC FG G declareSec(X, private, Ty, E
-          ) (|X, private|)::G
+--------------------------------------------- [S-DeclareSecPrivate]
+{secure PC FG G declareSec(X, private, Ty, E)
+             (X, private)::G}
 
 
 level PC FG G E public
----------------------------------------------- [S-DeclareSecPublic]
-secure public FG G declareSec(X, public, Ty, E
-                ) (|X, public|)::G
+------------------------------------------------ [S-DeclareSecPublic]
+{secure public FG G declareSec(X, public, Ty, E)
+                   (X, public)::G}
 
 
 /*To assign to public var, need both PC and expr to be public*/
@@ -285,7 +285,7 @@ secure_fun FG fun(Name, RetTy, RetName, Params, Body)
 
 
 paramsToSecCtx Params G
-secure PC FG (|RetName, RetSec|)::G Body G2
+secure PC FG (RetName, RetSec)::G Body G2
 ------------------------------------------------------ [SF-Secfun]
 secure_fun FG secfun(Name, PC, RetTy, RetSec, RetName,
                      Params, Body)
@@ -303,13 +303,13 @@ paramsToSecCtx endParams []
 
 
 paramsToSecCtx Rest SRest
----------------------------------------------------------- [PtSC-Add]
-paramsToSecCtx addParams(X, Ty, Rest) (|X, public|)::SRest
+-------------------------------------------------------- [PtSC-Add]
+paramsToSecCtx addParams(X, Ty, Rest) (X, public)::SRest
 
 
 paramsToSecCtx Rest SRest
--------------------------------------------------------- [PtSC-AddSec]
-paramsToSecCtx addSecParams(X, S, Ty, Rest) (|X, S|)::SRest
+--------------------------------------------------------- [PtSC-AddSec]
+paramsToSecCtx addSecParams(X, S, Ty, Rest) (X, S)::SRest
 
 
 |{params}- P ~~> PT

--- a/examples/functions/security/security.sos
+++ b/examples/functions/security/security.sos
@@ -41,13 +41,13 @@ Translation seclevel :
 
 no_lookup G X /*still can't overwrite existing decls*/
 typeOf FG G E Ty
------------------------------------------------- [T-DeclareSec]
-typeOK FG G declareSec(X, S, Ty, E) (|X, Ty|)::G
+---------------------------------------------- [T-DeclareSec]
+typeOK FG G declareSec(X, S, Ty, E) (X, Ty)::G
 
 
 eval_e FG G E V O
-------------------------------------------------- [E-DeclareSec]
-eval_c FG G declareSec(X, S, Ty, E) (|X, V|)::G O
+----------------------------------------------- [E-DeclareSec]
+eval_c FG G declareSec(X, S, Ty, E) (X, V)::G O
 
 
 
@@ -59,8 +59,8 @@ paramsToTyList addSecParams(X, S, Ty, Rest) Ty::TRest
 
 
 paramsToTyCtx Rest TRest
--------------------------------------------------------- [PtTC-AddSec]
-paramsToTyCtx addSecParams(X, S, Ty, Rest) (|X, Ty|)::TRest
+--------------------------------------------------------- [PtTC-AddSec]
+paramsToTyCtx addSecParams(X, S, Ty, Rest) (X, Ty)::TRest
 
 
 paramsToNameList Rest NRest
@@ -72,7 +72,7 @@ paramsToNameList addSecParams(X, S, Ty, Rest) X::NRest
 /*Host Relations for New Fun*/
 
 paramsToTyCtx Params G
-typeOK FG (|RetName, RetTy|)::G Body G2 /*ret name declared*/
+typeOK FG (RetName, RetTy)::G Body G2 /*ret name declared*/
 ------------------------------------------------------------ [T-Secfun]
 funTyOK FG secfun(Name, Level, RetTy, RetSec, RetName, Params, Body)
 
@@ -85,6 +85,6 @@ getFunTy secfun(Name, Level, RetTy, RetSec, RetName, Params, Body
 
 paramsToNameList Params Names
 --------------------------------------------------------- [EF-Secfun]
-eval_fun secfun(Name, Level, RetTy, RetSec, RetName, Params, Body
-               ) Name RetName Names Body
+{eval_fun secfun(Name, Level, RetTy, RetSec, RetName, Params, Body)
+                  Name RetName Names Body}
 

--- a/examples/imp/host/eval.sos
+++ b/examples/imp/host/eval.sos
@@ -6,9 +6,9 @@ bval ::= btrue | bfalse
 Translation bval :
 
 
-Judgment eval_a : [(|string, int|)] a* int
-Judgment eval_b : [(|string, int|)] b* bval
-Judgment eval_c : [(|string, int|)] c* [(|string, int|)]
+Judgment eval_a : [(string, int)] a* int
+Judgment eval_b : [(string, int)] b* bval
+Judgment eval_c : [(string, int)] c* [(string, int)]
 
 
 
@@ -119,8 +119,8 @@ eval_c E1 seq(C1, C2) E3
 
 
 eval_a E A I
---------------------------------- [E-Assign]
-eval_c E assign(X, A) (|X, I|)::E
+------------------------------- [E-Assign]
+eval_c E assign(X, A) (X, I)::E
 
 
 eval_b E B btrue

--- a/examples/imp/security/security.sos
+++ b/examples/imp/security/security.sos
@@ -29,9 +29,9 @@ smax public public public
 
 
 /*Security Analysis*/
-Judgment sec_level_a : [(|string, status|)] a* status
-Judgment sec_level_b : [(|string, status|)] b* status
-Judgment is_secure : status [(|string, status|)] c* /*program counter, ctx, cmd*/
+Judgment sec_level_a : [(string, status)] a* status
+Judgment sec_level_b : [(string, status)] b* status
+Judgment is_secure : status [(string, status)] c* /*program counter, ctx, cmd*/
 
 
 

--- a/examples/sec_SOS/host/eval.sos
+++ b/examples/sec_SOS/host/eval.sos
@@ -1,8 +1,7 @@
 Module sec_SOS:host
 
 Judgment eval_e : [(string, value)] e* value
-Judgment eval_rf : {[(string, value)] recFieldExprs*
-                    [(string, value)]}
+Judgment eval_rf : [(string, value)] recFieldExprs* [(string, value)]
 Judgment eval_c : [(string, value)] c* [(string, value)]
 
 

--- a/examples/sec_SOS/host/eval.sos
+++ b/examples/sec_SOS/host/eval.sos
@@ -1,9 +1,9 @@
 Module sec_SOS:host
 
-Judgment eval_e : [(|string, value|)] e* value
-Judgment eval_rf : {[(|string, value|)] recFieldExprs*
-                    [(|string, value|)]}
-Judgment eval_c : [(|string, value|)] c* [(|string, value|)]
+Judgment eval_e : [(string, value)] e* value
+Judgment eval_rf : {[(string, value)] recFieldExprs*
+                    [(string, value)]}
+Judgment eval_c : [(string, value)] c* [(string, value)]
 
 
 /*Expression Evaluation*/
@@ -114,8 +114,8 @@ eval_rf G endRecFieldExprs []
 
 eval_e G E V
 eval_rf G Rest FVs
----------------------------------------------------- [ERF-Add]
-eval_rf G addRecFieldExprs(L, E, Rest) (|L, V|)::FVs
+-------------------------------------------------- [ERF-Add]
+eval_rf G addRecFieldExprs(L, E, Rest) (L, V)::FVs
 
 
 
@@ -132,13 +132,13 @@ eval_c G seq(C1, C2) G2
 
 
 eval_e G E V
--------------------------------------- [E-Declare]
-eval_c G declare(X, Ty, E) (|X, V|)::G
+------------------------------------ [E-Declare]
+eval_c G declare(X, Ty, E) (X, V)::G
 
 
 eval_e G E V
---------------------------------- [E-Assign]
-eval_c G assign(X, E) (|X, V|)::G
+------------------------------- [E-Assign]
+eval_c G assign(X, E) (X, V)::G
 
 
 eval_e G Cond trueVal
@@ -175,17 +175,17 @@ eval_c G recUpdate(Rec, RecFields, E) Result
 /*Update the associations in the first tyCtx for the fields,
   descending through it to place the value in the final one, producing
   the ending tyCtx*/
-Judgment update_rec_fields : recFields* [(|string, value|)] value [(|string, value|)]
+Judgment update_rec_fields : recFields* [(string, value)] value [(string, value)]
 
---------------------------------------------------- [URF-One]
-update_rec_fields oneField(F) Init V (|F, V|)::Init
+------------------------------------------------- [URF-One]
+update_rec_fields oneField(F) Init V (F, V)::Init
 
 
 lookup Init F recVal(FFields)
 update_rec_fields Rest FFields V UpdatedFFields
 ----------------------------------------------- [URF-Step]
 {update_rec_fields addField(F, Rest) Init V
-    (|F, recVal(UpdatedFFields)|)::Init}
+    (F, recVal(UpdatedFFields))::Init}
 
 
 
@@ -210,14 +210,14 @@ val_eq recVal(Fields1) recVal(Fields2)
 
 
 
-Fixed Judgment evalctx_eq : [(|string, value|)] [(|string, value|)]
+Fixed Judgment evalctx_eq : [(string, value)] [(string, value)]
 
 ================ [ECEq-Empty]
 evalctx_eq [] []
 
 
-select (|X, V2|) EC2 Rest2
+select (X, V2) EC2 Rest2
 val_eq V1 V2
 evalctx_eq Rest1 Rest2
-=============================== [ECEq-Add]
-evalctx_eq (|X, V1|)::Rest1 EC2
+============================= [ECEq-Add]
+evalctx_eq (X, V1)::Rest1 EC2

--- a/examples/sec_SOS/host/host.conc
+++ b/examples/sec_SOS/host/host.conc
@@ -88,7 +88,7 @@ type_c<ty> ::= intTy_t ~~> intTy
              | lcurly_t rcurly_t ~~> recTy([])
              | lcurly_t Fields::recTyFields_c rcurly_t ~~>
                   recTy(Fields)
-recTyFields_c<[(|string, ty|)]> ::=
-   | Field::name_t colon_t Ty::type_c ~~> [(|Field, Ty|)]
+recTyFields_c<[(string, ty)]> ::=
+   | Field::name_t colon_t Ty::type_c ~~> [(Field, Ty)]
    | Field::name_t colon_t Ty::type_c semi_t Rest::recTyFields_c ~~>
-        (|Field, Ty|)::Rest
+        (Field, Ty)::Rest

--- a/examples/sec_SOS/host/syntax.sos
+++ b/examples/sec_SOS/host/syntax.sos
@@ -37,7 +37,7 @@ Translation recFields :
 /*Types*/
 ty ::= intTy
      | boolTy
-     | recTy([(|string, ty|)])
+     | recTy([(string, ty)])
 Translation ty :
 
 
@@ -45,6 +45,6 @@ Translation ty :
 value ::= intVal(int)
         | trueVal
         | falseVal
-        | recVal([(|string, value|)])
+        | recVal([(string, value)])
 Translation value :
 

--- a/examples/sec_SOS/host/typing.sos
+++ b/examples/sec_SOS/host/typing.sos
@@ -1,8 +1,7 @@
 Module sec_SOS:host
 
 Judgment typeOf : [(string, ty)] e* ty
-Judgment typeRecFields : {[(string, ty)] recFieldExprs*
-                          [(string, ty)]}
+Judgment typeRecFields : [(string, ty)] recFieldExprs* [(string, ty)]
 Judgment typeOK : [(string, ty)] c* [(string, ty)]
 
 

--- a/examples/sec_SOS/host/typing.sos
+++ b/examples/sec_SOS/host/typing.sos
@@ -1,9 +1,9 @@
 Module sec_SOS:host
 
-Judgment typeOf : [(|string, ty|)] e* ty
-Judgment typeRecFields : {[(|string, ty|)] recFieldExprs*
-                          [(|string, ty|)]}
-Judgment typeOK : [(|string, ty|)] c* [(|string, ty|)]
+Judgment typeOf : [(string, ty)] e* ty
+Judgment typeRecFields : {[(string, ty)] recFieldExprs*
+                          [(string, ty)]}
+Judgment typeOK : [(string, ty)] c* [(string, ty)]
 
 
 /*Expression Typing*/
@@ -76,8 +76,8 @@ typeRecFields G endRecFieldExprs []
 typeOf G E Ty
 typeRecFields G Rest FTys
 no_lookup FTys L /*each label only occurs once*/
------------------------------------------------------------- [TRF-Add]
-typeRecFields G addRecFieldExprs(L, E, Rest) (|L, Ty|)::FTys
+---------------------------------------------------------- [TRF-Add]
+typeRecFields G addRecFieldExprs(L, E, Rest) (L, Ty)::FTys
 
 
 
@@ -95,8 +95,8 @@ typeOK G seq(C1, C2) G2
 
 no_lookup G X /*can't overwrite existing decls*/
 typeOf G E Ty
---------------------------------------- [T-Declare]
-typeOK G declare(X, Ty, E) (|X, Ty|)::G
+------------------------------------- [T-Declare]
+typeOK G declare(X, Ty, E) (X, Ty)::G
 
 
 typeOf G E Ty
@@ -130,7 +130,7 @@ typeOK G recUpdate(Rec, Fields, E) G
 
 /*Check whether the update to the nested fields is valid
   The tyctx is the fields of the record*/
-Judgment checkRecUpdate : recFields* [(|string, ty|)] ty
+Judgment checkRecUpdate : recFields* [(string, ty)] ty
 
 lookup RecFieldTys F Ty
 ----------------------------------------- [CRU-OneField]
@@ -169,7 +169,7 @@ typeOfVal recVal(Fields) recTy(FTys)
 
 /*Typing for evaluation contexts to allow type soundness and recVal
   typing*/
-Fixed Judgment typeOfEvalctx : [(|string, value|)] [(|string, ty|)]
+Fixed Judgment typeOfEvalctx : [(string, value)] [(string, ty)]
 
 =================== [TEC-Empty]
 typeOfEvalctx [] []
@@ -177,6 +177,6 @@ typeOfEvalctx [] []
 
 typeOfVal V Ty
 typeOfEvalctx Rest RestTys
-=============================================== [TEC-Add]
-typeOfEvalctx (|X, V|)::Rest (|X, Ty|)::RestTys
+=========================================== [TEC-Add]
+typeOfEvalctx (X, V)::Rest (X, Ty)::RestTys
 

--- a/examples/sec_SOS/list/list.sos
+++ b/examples/sec_SOS/list/list.sos
@@ -79,10 +79,10 @@ ty ::= ...
 /*Strictly speaking, an empty list doesn't have the head or tail
   fields.  However, we don't have any translation constraints, so we
   can do whatever we want, and this is close.*/
---------------------------------------------------- [Trans-ListTy]
+----------------------------------------------- [Trans-ListTy]
 |{ty}- listTy(T) ~~>
-       recTy([(|"head", T|), (|"tail", listTy(T)|),
-              (|"null", boolTy|)])
+       recTy([("head", T), ("tail", listTy(T)),
+              ("null", boolTy)])
 
 
 
@@ -92,11 +92,11 @@ value ::= ...
         | consVal(value, value)
 
 
--------------------------------------------------- [Trans-NilVal]
-|{value}- nilVal ~~> recVal([(|"null", trueVal|)])
+------------------------------------------------ [Trans-NilVal]
+|{value}- nilVal ~~> recVal([("null", trueVal)])
 
 
-------------------------------------------------- [Trans-ConsVal]
+--------------------------------------------- [Trans-ConsVal]
 |{value}- consVal(Hd, Tl) ~~>
-          recVal([(|"head", Hd|), (|"tail", Tl|),
-                  (|"null", falseVal|)])
+          recVal([("head", Hd), ("tail", Tl),
+                  ("null", falseVal)])

--- a/examples/sec_SOS/security/analysis.sos
+++ b/examples/sec_SOS/security/analysis.sos
@@ -19,8 +19,7 @@ join S private private
 
 Judgment level : [(string, seclevel)] e* seclevel
 Judgment rf_level : [(string, seclevel)] recFieldExprs* seclevel
-Judgment secure : {seclevel [(string, seclevel)] c*
-                   [(string, seclevel)]}
+Judgment secure : seclevel [(string, seclevel)] c* [(string, seclevel)]
 
 
 /*Expression Security Level*/

--- a/examples/sec_SOS/security/analysis.sos
+++ b/examples/sec_SOS/security/analysis.sos
@@ -17,10 +17,10 @@ join S private private
 
 
 
-Judgment level : [(|string, seclevel|)] e* seclevel
-Judgment rf_level : [(|string, seclevel|)] recFieldExprs* seclevel
-Judgment secure : {seclevel [(|string, seclevel|)] c*
-                   [(|string, seclevel|)]}
+Judgment level : [(string, seclevel)] e* seclevel
+Judgment rf_level : [(string, seclevel)] recFieldExprs* seclevel
+Judgment secure : {seclevel [(string, seclevel)] c*
+                   [(string, seclevel)]}
 
 
 /*Expression Security Level*/
@@ -127,20 +127,20 @@ secure PC G seq(C1, C2) G2
 
 
 level G E public
----------------------------------------------- [S-Declare]
-secure PC G declare(X, Ty, E) (|X, public|)::G
+-------------------------------------------- [S-Declare]
+secure PC G declare(X, Ty, E) (X, public)::G
 
 
 level G E S
 ------------------------------------------ [S-DeclareSecPrivate]
 {secure PC G declareSec(X, private, Ty, E)
-        (|X, private|)::G}
+        (X, private)::G}
 
 
 level G E public
 --------------------------------------------- [S-DeclareSecPublic]
 {secure public G declareSec(X, public, Ty, E)
-        (|X, public|)::G}
+        (X, public)::G}
 
 
 /*To assign to public var, need both PC and expr to be public*/

--- a/examples/sec_SOS/security/security.sos
+++ b/examples/sec_SOS/security/security.sos
@@ -21,11 +21,11 @@ Translation seclevel :
 
 no_lookup G X /*still can't overwrite existing decls*/
 typeOf G E Ty
---------------------------------------------- [T-DeclareSec]
-typeOK G declareSec(X, S, Ty, E) (|X, Ty|)::G
+------------------------------------------- [T-DeclareSec]
+typeOK G declareSec(X, S, Ty, E) (X, Ty)::G
 
 
 eval_e G E V
--------------------------------------------- [E-DeclareSec]
-eval_c G declareSec(X, S, Ty, E) (|X, V|)::G
+------------------------------------------ [E-DeclareSec]
+eval_c G declareSec(X, S, Ty, E) (X, V)::G
 

--- a/examples/stlc/host/stlc.sos
+++ b/examples/stlc/host/stlc.sos
@@ -12,11 +12,11 @@ type ::= arrow(type, type)
 
 
 /*Judgments*/
-Judgment typeOf : [(|string, type|)] term* type
+Judgment typeOf : [(string, type)] term* type
 
 /*Translation Types*/
-Translation term : [(|string, type|)] /*ctx |- term ~~> term*/
-Translation type :                    /*|- type ~~> type*/
+Translation term : [(string, type)] /*ctx |- term ~~> term*/
+Translation type :                  /*|- type ~~> type*/
 
 
 /*Typing Rules*/
@@ -27,7 +27,7 @@ typeOf G T2 Ty1
 typeOf G app(T1, T2) Ty2
 
 
-typeOf (|X, Ty1|)::G Body Ty2
+typeOf (X, Ty1)::G Body Ty2
 ------------------------------------------ [T-Abs]
 typeOf G abs(X, Ty1, Body) arrow(Ty1, Ty2)
 

--- a/examples/stlc/let/let.sos
+++ b/examples/stlc/let/let.sos
@@ -10,7 +10,7 @@ term ::= ...
 
 /*Typing Rule*/
 typeOf G T1 Ty1
-typeOf (|X, Ty1|)::G T2 Ty2
+typeOf (X, Ty1)::G T2 Ty2
 ---------------------------- [T-Let]
 typeOf G let(X, T1, T2) Ty2
 

--- a/examples/stlc/letPair/letPair.sos
+++ b/examples/stlc/letPair/letPair.sos
@@ -11,8 +11,8 @@ term ::= ...
 
 /*Typing Rule*/
 typeOf G T1 pairTy(Ty1)
-typeOf (|X, Ty1|)::(|Y, Ty1|)::G T2 Ty2
---------------------------------------- [T-LetPair]
+typeOf (X, Ty1)::(Y, Ty1)::G T2 Ty2
+----------------------------------- [T-LetPair]
 typeOf G letPair(X, Y, T1, T2) Ty2
 
 

--- a/grammars/sos/core/common/abstractSyntax/Type.sv
+++ b/grammars/sos/core/common/abstractSyntax/Type.sv
@@ -243,7 +243,7 @@ top::Type ::= ty::Type
 abstract production tupleType
 top::Type ::= tys::TypeList
 {
-  top.pp = "(|" ++ tys.pp_comma ++ "|)";
+  top.pp = "(" ++ tys.pp_comma ++ ")";
   top.name = error("Should not access tupleType.name");
 
   tys.subst = top.subst;

--- a/grammars/sos/core/common/concreteSyntax/Concrete.sv
+++ b/grammars/sos/core/common/concreteSyntax/Concrete.sv
@@ -24,10 +24,10 @@ concrete productions top::Type_c
   { top.ast = stringType(location=top.location); }
 | '[' x1::EmptyNewlines ty::Type_c x2::EmptyNewlines ']'
   { top.ast = listType(ty.ast, location=top.location); }
-| '(|' x::EmptyNewlines '|)'
+| '(' x::EmptyNewlines ')'
   { top.ast = tupleType(nilTypeList(location=top.location),
                         location=top.location); }
-| '(|' x1::EmptyNewlines tys::CommaTypeList_c x2::EmptyNewlines '|)'
+| '(' x1::EmptyNewlines tys::CommaTypeList_c x2::EmptyNewlines ')'
   { top.ast = tupleType(tys.ast, location=top.location); }
 | ty::LowerId_t
   { top.ast = nameType(toQName(ty.lexeme, ty.location),

--- a/grammars/sos/core/common/concreteSyntax/Terminals.sv
+++ b/grammars/sos/core/common/concreteSyntax/Terminals.sv
@@ -14,8 +14,8 @@ terminal IntTy_t      'int'      lexer classes {KEYWORD};
 
 terminal LBracket_t   '[';
 terminal RBracket_t   ']';
-terminal LBanana_t    '(|';
-terminal RBanana_t    '|)';
+terminal LParen_t     '(';
+terminal RParen_t     ')';
 
 terminal Comma_t      ',';
 
@@ -32,6 +32,15 @@ terminal Newline_t        /(\/\/[^\n]*)?\r?\n/   precedence=10;
 
 terminal LowerId_t      /[a-z][a-z0-9A-Z_]*/;
 terminal LowerQName_t   /([a-zA-Z_]+:)+[a-z][a-z0-9A-Z_]*/;
+--using these for constr(args) permits pairs to use parentheses
+terminal LowerIdParen_t      /[a-z][a-z0-9A-Z_]*\(/;
+terminal LowerQNameParen_t   /([a-zA-Z_]+:)+[a-z][a-z0-9A-Z_]*\(/;
+
+function dropNameParen
+String ::= x::String
+{
+  return substring(0, length(x) - 1, x);
+}
 
 
 ignore terminal Spacing_t   /[\ \t\r]+/;

--- a/grammars/sos/core/concreteDefs/abstractSyntax/Terms.sv
+++ b/grammars/sos/core/concreteDefs/abstractSyntax/Terms.sv
@@ -230,7 +230,7 @@ top::Term ::= hd::Term tl::Term
 abstract production tupleTerm
 top::Term ::= contents::TermList
 {
-  top.pp = "(|" ++ contents.pp ++ "|)";
+  top.pp = "(" ++ contents.pp ++ ")";
 
   top.type = tupleType(toTypeList(contents.typeList, top.location),
                        location=top.location);

--- a/grammars/sos/core/concreteDefs/concreteSyntax/Concrete.sv
+++ b/grammars/sos/core/concreteDefs/concreteSyntax/Concrete.sv
@@ -215,19 +215,25 @@ concrete productions top::Term3_c
 | constant::LowerQName_t
   { top.ast = nameTerm(toQName(constant.lexeme, constant.location),
                        location=top.location); }
-| constant::LowerId_t '(' x::EmptyNewlines ')'
-  { top.ast = nameTerm(toQName(constant.lexeme, constant.location),
+| constant::LowerIdParen_t --'(' is part of this
+  x::EmptyNewlines ')'
+  { top.ast = nameTerm(toQName(dropNameParen(constant.lexeme),
+                               constant.location),
                        location=top.location); }
-| constant::LowerQName_t '(' x::EmptyNewlines ')'
-  { top.ast = nameTerm(toQName(constant.lexeme, constant.location),
+| constant::LowerQNameParen_t --'(' is part of this
+  x::EmptyNewlines ')'
+  { top.ast = nameTerm(toQName(dropNameParen(constant.lexeme),
+                               constant.location),
                        location=top.location); }
-| prod::LowerId_t '(' x1::EmptyNewlines args::TermList_c
-  x2::EmptyNewlines ')'
-  { top.ast = applicationTerm(toQName(prod.lexeme, prod.location),
+| prod::LowerIdParen_t --'(' is part of this
+  x1::EmptyNewlines args::TermList_c x2::EmptyNewlines ')'
+  { top.ast = applicationTerm(toQName(dropNameParen(prod.lexeme),
+                                      prod.location),
                               args.ast, location=top.location); }
-| prod::LowerQName_t '(' x1::EmptyNewlines args::TermList_c
-  x2::EmptyNewlines ')'
-  { top.ast = applicationTerm(toQName(prod.lexeme, prod.location),
+| prod::LowerQNameParen_t --'(' is part of this
+  x1::EmptyNewlines args::TermList_c x2::EmptyNewlines ')'
+  { top.ast = applicationTerm(toQName(dropNameParen(prod.lexeme),
+                                      prod.location),
                               args.ast, location=top.location); }
 | index::ProdPart_t
   { top.ast = prodIndex(index.lexeme, location=top.location); }
@@ -242,7 +248,7 @@ concrete productions top::Term3_c
   { top.ast = nilTerm(location=top.location); }
 | '[' tms::TermList_c ']'
   { top.ast = tms.listAST; }
-| '(|' tms::TermList_c '|)'
+| '(' tms::TermList_c ')'
   { top.ast = tupleTerm(tms.ast, location=top.location); }
 
 concrete productions top::TermList_c

--- a/grammars/sos/core/concreteDefs/concreteSyntax/Terminals.sv
+++ b/grammars/sos/core/concreteDefs/concreteSyntax/Terminals.sv
@@ -14,8 +14,6 @@ terminal String_t    /"([^"]|(\\"))*"/;
 terminal ProdPart_t   /[A-Z][a-z0-9A-Z_]*/;
 terminal ToInt_t      '$to_int';
 
-terminal LParen_t   '(' lexer classes {REGEX_SYMBOL};
-terminal RParen_t   ')' lexer classes {REGEX_SYMBOL};
 terminal LAngle_t   '<';
 terminal RAngle_t   '>';
 terminal Comma_t    ',';
@@ -33,7 +31,7 @@ terminal RBracket_t   ']' lexer classes {REGEX_SYMBOL};
 terminal Star_t       '*' lexer classes {REGEX_SYMBOL};
 terminal Plus_t       '+' lexer classes {REGEX_SYMBOL};
 terminal Or_t         '|' lexer classes {REGEX_SYMBOL};
-terminal Char_t       /.|(\\[\ ntr\-\/\\abf+*|()\[\]])|(\\[0-9][0-9][0-9])/ submits to {KEYWORD, Slash_t, Spacing_t};
+terminal Char_t       /.|(\\[\ ntr\-\/\\abf+*|()\[\]])|(\\[0-9][0-9][0-9])/ submits to {KEYWORD, LParen_t, RParen_t, Slash_t, Spacing_t};
 terminal Range_t      '-' lexer classes {REGEX_SYMBOL};
 
 terminal ColonsEq_t   '::=';

--- a/grammars/sos/core/main/abstractSyntax/Expr.sv
+++ b/grammars/sos/core/main/abstractSyntax/Expr.sv
@@ -662,7 +662,7 @@ top::Expr ::= s::String
 abstract production tupleExpr
 top::Expr ::= contents::Args
 {
-  top.pp = "(|" ++ contents.pp ++ "|)";
+  top.pp = "(" ++ contents.pp ++ ")";
 
   contents.downVarTypes = top.downVarTypes;
   contents.lastFun = toQName("<tuple>", top.location);

--- a/grammars/sos/core/main/concreteSyntax/Concrete.sv
+++ b/grammars/sos/core/main/concreteSyntax/Concrete.sv
@@ -181,22 +181,29 @@ concrete productions top::FactorExpr_c
   { top.ast = varExpr(name.lexeme, location=top.location); }
 | num::Integer_t
   { top.ast = intExpr(toInteger(num.lexeme), location=top.location); }
-| name::LowerQName_t '(' args::Args_c ')'
-  { top.ast = funCall(toQName(name.lexeme, name.location), args.ast,
+| name::LowerQNameParen_t --'(' is part of this
+  args::Args_c ')'
+  { top.ast = funCall(toQName(dropNameParen(name.lexeme),
+                              name.location), args.ast,
                       location=top.location); }
-| name::LowerId_t '(' args::Args_c ')'
-  { top.ast = funCall(toQName(name.lexeme, name.location), args.ast,
+| name::LowerIdParen_t --'(' is part of this
+  args::Args_c ')'
+  { top.ast = funCall(toQName(dropNameParen(name.lexeme),
+                              name.location), args.ast,
                       location=top.location); }
-| name::LowerQName_t '(' ')'
-  { top.ast = funCall(toQName(name.lexeme, name.location),
+| name::LowerQNameParen_t ')' --'(' is part of LowerQNameParen_t
+  { top.ast = funCall(toQName(dropNameParen(name.lexeme),
+                              name.location),
                       nilArgs(location=top.location),
                       location=top.location); }
-| name::LowerId_t '(' ')'
-  { top.ast = funCall(toQName(name.lexeme, name.location),
+| name::LowerIdParen_t ')' --'(' is part of LowerId_t
+  { top.ast = funCall(toQName(dropNameParen(name.lexeme),
+                              name.location),
                       nilArgs(location=top.location),
                       location=top.location); }
-| '(|' a::Args_c '|)'
-  { top.ast = tupleExpr(a.ast, location=top.location); }
+| '(' e::MainExpr_c ',' a::Args_c ')'
+  { top.ast = tupleExpr(consArgs(e.ast, a.ast, location=top.location),
+                        location=top.location); }
 | s::String_t
   { top.ast = stringExpr(substring(1, length(s.lexeme) - 1, s.lexeme),
                          location=top.location); }

--- a/grammars/sos/core/semanticDefs/abstractSyntax/Term.sv
+++ b/grammars/sos/core/semanticDefs/abstractSyntax/Term.sv
@@ -176,7 +176,7 @@ top::Term ::= constructor::QName args::TermList
 abstract production tupleTerm
 top::Term ::= contents::TermList
 {
-  top.pp = "(|" ++ contents.pp_comma ++ "|)";
+  top.pp = "(" ++ contents.pp_comma ++ ")";
 
   contents.moduleName = top.moduleName;
 
@@ -278,7 +278,7 @@ top::Term ::= hd::Term tl::Term
 abstract production ascriptionTerm
 top::Term ::= tm::Term ty::Type
 {
-  top.pp = "(|" ++ tm.pp ++ " : " ++ ty.pp ++ "|)";
+  top.pp = "(" ++ tm.pp ++ " : " ++ ty.pp ++ ")";
 
   tm.moduleName = top.moduleName;
 

--- a/grammars/sos/core/semanticDefs/concreteSyntax/Concrete.sv
+++ b/grammars/sos/core/semanticDefs/concreteSyntax/Concrete.sv
@@ -560,41 +560,36 @@ concrete productions top::NonNameTerm_c
   { top.ast =
         stringConst(substring(1, length(s.lexeme) - 1, s.lexeme),
                     location=top.location); }
-| constructor::LowerId_t
-  '(' x1::EmptyNewlines args::ContainedCommaTermList_c ')'
+| constructor::LowerIdParen_t --'(' is part of this
+  x1::EmptyNewlines args::ContainedCommaTermList_c ')'
   { top.ast =
-        appTerm(toQName(constructor.lexeme,
+        appTerm(toQName(dropNameParen(constructor.lexeme),
                         constructor.location),
                 args.ast, location=top.location); }
-| constructor::LowerQName_t
-  '(' x1::EmptyNewlines args::ContainedCommaTermList_c ')'
+| constructor::LowerQNameParen_t --'(' is part of this
+  x1::EmptyNewlines args::ContainedCommaTermList_c ')'
   { top.ast =
-        appTerm(toQName(constructor.lexeme,
+        appTerm(toQName(dropNameParen(constructor.lexeme),
                         constructor.location),
                 args.ast, location=top.location); }
-| constructor::LowerId_t '(' x::EmptyNewlines ')'
+| constructor::LowerIdParen_t --'(' is part of this
+  x::EmptyNewlines ')'
   { top.ast =
-        appTerm(toQName(constructor.lexeme,
+        appTerm(toQName(dropNameParen(constructor.lexeme),
                         constructor.location),
                 nilTermList(location=top.location),
                 location=top.location); }
-| constructor::LowerQName_t '(' x::EmptyNewlines ')'
+| constructor::LowerQNameParen_t --'(' is part of this
+  x::EmptyNewlines ')'
   { top.ast =
-        appTerm(toQName(constructor.lexeme,
+        appTerm(toQName(dropNameParen(constructor.lexeme),
                         constructor.location),
                 nilTermList(location=top.location),
                 location=top.location); }
-  {-
-    Tuples are delimited by '(|' and '|)' because using only
-    parentheses creates ambiguities with constructors:  We can't tell
-    whether "x (1, 2)" is supposed to be a single term, a constructor
-    x with arguments 1 and 2, or two terms, a constructor x without
-    arguments and a tuple.
-  -}
-| '(|' x1::EmptyNewlines '|)'
+| '(' x1::EmptyNewlines ')'
   { top.ast = tupleTerm(nilTermList(location=top.location),
                         location=top.location); }
-| '(|' x1::EmptyNewlines contents::ContainedCommaTermList_c '|)'
+| '(' x1::EmptyNewlines contents::ContainedCommaTermList_c ')'
   { top.ast =
         case contents.ast.toList of
         | [t] -> t
@@ -606,13 +601,8 @@ concrete productions top::NonNameTerm_c
   { top.ast = contents.listTerm; }
 | hd::Term_c '::' x1::EmptyNewlines tl::Term_c
   { top.ast = consTerm(hd.ast, tl.ast, location=top.location); }
-  {-
-    Ascription uses bananas because other delimiters we might use
-    cause ambiguities.  Using bananas might confuse because it isn't a
-    tuple, it is a single term for which we are specifying the type.
-  -}
-| '(|' x1::EmptyNewlines t::Term_c x2::EmptyNewlines ':'
-       x3::EmptyNewlines ty::Type_c x4::EmptyNewlines '|)'
+| '(' x1::EmptyNewlines t::Term_c x2::EmptyNewlines ':'
+      x3::EmptyNewlines ty::Type_c x4::EmptyNewlines ')'
   { top.ast = ascriptionTerm(t.ast, ty.ast, location=top.location); }
 
 

--- a/grammars/sos/core/semanticDefs/concreteSyntax/Terminals.sv
+++ b/grammars/sos/core/semanticDefs/concreteSyntax/Terminals.sv
@@ -36,9 +36,6 @@ terminal App_t     '++';
 
 terminal Negate_t   '!';
 
-terminal LParen_t   '(';
-terminal RParen_t   ')';
-
 terminal Cons_t     '::'   association=right;
 terminal LCurly_t   '{';
 terminal RCurly_t   '}';

--- a/ide/sos-ext-main.el
+++ b/ide/sos-ext-main.el
@@ -39,10 +39,10 @@
     (regexp-opt sos-ext-main-keyword-list 'words)
     font-lock-keyword-face)
    ;;Types
-   '(":[ \t\n]*\\(\\([ a-zA-Z0-9_:,\\[(|)]\\|\\]\\)+\\)[ \t\n]*>"
+   '(":[ \t\n]*\\(\\([ a-zA-Z0-9_:,\\[()]\\|\\]\\)+\\)[ \t\n]*>"
      (1 font-lock-type-face))
    '("Parse[ \t\n]+\\([a-zA-Z0-9_:]+\\)" (1 font-lock-type-face))
-   '("->[ \t\n]*\\(\\([ a-zA-Z0-9_:,\\[(|)]\\|\\]\\)+\\){"
+   '("->[ \t\n]*\\(\\([ a-zA-Z0-9_:,\\[()]\\|\\]\\)+\\){"
      (1 font-lock-type-face))
    ;;Variable names
    '("<[ \t\n]*\\([a-zA-Z0-9_]+\\)[ \t\n]*:" ;function parameters

--- a/ide/sos-ext.el
+++ b/ide/sos-ext.el
@@ -49,13 +49,13 @@
    '("=====[=]*[ \t]*\\[[-a-zA-Z0-9_]+\\(\\]\\)"
      (1 font-lock-keyword-face))
    ;;Types
-   '("Judgment[ \t\n]+[a-zA-Z0-9_]+[ \t\n]*:[ \t]*\\(\\([ \ta-zA-Z0-9_:,\\*\\[(|)]\\|\\]\\)+\\)"
+   '("Judgment[ \t\n]+[a-zA-Z0-9_]+[ \t\n]*:[ \t]*\\(\\([ \ta-zA-Z0-9_:,\\*\\[()]\\|\\]\\)+\\)"
      (1 font-lock-type-face)) ;judgment types
-   '("Translation[ \t\n]+[a-zA-Z0-9_]+[ \t\n]*:[ \t]*\\(\\([ \ta-zA-Z0-9_:,\\*\\[(|)]\\|\\]\\)+\\)"
+   '("Translation[ \t\n]+[a-zA-Z0-9_]+[ \t\n]*:[ \t]*\\(\\([ \ta-zA-Z0-9_:,\\*\\[()]\\|\\]\\)+\\)"
      (1 font-lock-type-face)) ;translation types
-   '("Judgment[ \t\n]+[a-zA-Z0-9_]+[ \t\n]*:[ \t]*{\\(\\([ \t\na-zA-Z0-9_:,\\*\\[(|)]\\|\\]\\)+\\)}"
+   '("Judgment[ \t\n]+[a-zA-Z0-9_]+[ \t\n]*:[ \t]*{\\(\\([ \t\na-zA-Z0-9_:,\\*\\[()]\\|\\]\\)+\\)}"
      (1 font-lock-type-face)) ;judgment types in curly braces
-   '("Translation[ \t\n]+[a-zA-Z0-9_]+[ \t\n]*:[ \t]*{\\(\\([ \t\na-zA-Z0-9_:,\\*\\[(|)]\\|\\]\\)+\\)}"
+   '("Translation[ \t\n]+[a-zA-Z0-9_]+[ \t\n]*:[ \t]*{\\(\\([ \t\na-zA-Z0-9_:,\\*\\[()]\\|\\]\\)+\\)}"
      (1 font-lock-type-face)) ;translation types in curly braces
    '("\\([a-zA-Z0-9:_]+\\)[ ]+::=" ;defined categories
      (1 font-lock-type-face))

--- a/stdLib/lists.sos
+++ b/stdLib/lists.sos
@@ -5,10 +5,10 @@ Module stdLib
 */
 
 /*Find the first item associated with the key*/
-Fixed Judgment lookup : [(|Key, Item|)] Key Item
+Fixed Judgment lookup : [(Key, Item)] Key Item
 
 /*Holds if no items are associated with the key*/
-Fixed Judgment no_lookup : [(|Key, Item|)] Key
+Fixed Judgment no_lookup : [(Key, Item)] Key
 
 /*Holds if the item is in the list*/
 Fixed Judgment mem : Item [Item]
@@ -23,7 +23,7 @@ Fixed Judgment select : Item [Item] [Item]
 Fixed Judgment subset : [A] [A]
 
 /*Domain of a list (first element of each pair)*/
-Fixed Judgment domain : [(|A, B|)] [A]
+Fixed Judgment domain : [(A, B)] [A]
 
 
 
@@ -32,14 +32,14 @@ Fixed Judgment domain : [(|A, B|)] [A]
 */
 
 
-===================================== [Lkp-Here]
-lookup (|Key, Value|)::Rest Key Value
+=================================== [Lkp-Here]
+lookup (Key, Value)::Rest Key Value
 
 
 K != Key
 lookup Rest Key Value
-=============================== [Lkp-Later]
-lookup (|K, V|)::Rest Key Value
+============================= [Lkp-Later]
+lookup (K, V)::Rest Key Value
 
 
 
@@ -50,8 +50,8 @@ no_lookup [] Key
 
 K != Key
 no_lookup Rest Key
-============================ [NLkp-Cons]
-no_lookup (|K, V|)::Rest Key
+========================== [NLkp-Cons]
+no_lookup (K, V)::Rest Key
 
 
 
@@ -95,5 +95,5 @@ domain [] []
 
 
 domain Rest DRest
-============================== [Dmn-Cons]
-domain (|A, B|)::Rest A::DRest
+============================ [Dmn-Cons]
+domain (A, B)::Rest A::DRest

--- a/tests/basics/base/errors.main
+++ b/tests/basics/base/errors.main
@@ -44,7 +44,7 @@ Error Expected "Duplicate parameters" {
 Error Expected "Cannot unify" {
   Error Expected "names but found" {
     Function tooManyLetNames : <X : int> -> int {
-      Let A, B, C := (|1, 2|) In A
+      Let A, B, C := (1, 2) In A
     }
   }
 }
@@ -53,7 +53,7 @@ Error Expected "Cannot unify" {
 Error Expected "Cannot unify []" {
   Error Expected "Expected 1 names but found 2" {
     Function tooFewLetNames : <X : int> -> int {
-      Let A, B := (|1, 2, 3|) In B
+      Let A, B := (1, 2, 3) In B
     }
   }
 }

--- a/tests/basics/base/errors.sos
+++ b/tests/basics/base/errors.sos
@@ -32,7 +32,7 @@ Error Expected "only define new constructors for user-defined types" {
 
 /*Translation for non-existent type*/
 Error Expected "Translation declared for unknown type" {
-  Translation nonexistentType : [(|string, type|)]
+  Translation nonexistentType : [(string, type)]
 }
 
 /*Translation type not declared*/
@@ -64,7 +64,7 @@ Error Expected "Invalid primary component" {
 }
 Error Expected "must be an extensible type" {
   Error Expected "primary component is not extensible" {
-    Judgment nonExtensiblePC : [(|string, type|)] string* type
+    Judgment nonExtensiblePC : [(string, type)] string* type
   }
 }
 Error Expected "Two primary components" {
@@ -239,8 +239,8 @@ Error Expected "Cannot unify" {
   typeErrors A
 }
 Error Expected "Cannot unify" {
-  [3, 4] = (|3, 4|)
-  ================= [TE-Rule2]
+  [3, 4] = (3, 4)
+  =============== [TE-Rule2]
   typeErrors A
 }
 Error Expected "Cannot unify" {
@@ -260,8 +260,8 @@ Error Expected "Cannot unify" {
   typeErrors A
 }
 Error Expected "Cannot unify" {
-  (|W : string|) = X
+  (W : string) = X
   X - Y = Z
-  ================== [TE-Rule6]
+  ================ [TE-Rule6]
   typeErrors A
 }


### PR DESCRIPTION
Originally, tuples used bananas (`(|` and `|)`) because basic parentheses conflicted with constructors.  For example, we couldn't tell if `c (1, 2)` was meant to be a constructor `c` applied to `1` and `2` as arguments, or if it was a constructor `c` with no arguments and a pair.

This is now solved by requiring no space between the name and opening parenthesis when the constructor with arguments is intended, and space when it is supposed to be a constructor without arguments and a pair.