### PR TITLE
Add values relation to standard library

### DIFF
--- a/stdLib/lists.sos
+++ b/stdLib/lists.sos
@@ -25,6 +25,9 @@ Fixed Judgment subset : [A] [A]
 /*Domain of a list (first element of each pair)*/
 Fixed Judgment domain : [(|A, B|)] [A]
 
+/*Values of a pair list (second element of each pair)*/
+Fixed Judgment values : [(|A, B|)] [B]
+
 
 
 /*
@@ -97,3 +100,14 @@ domain [] []
 domain Rest DRest
 ============================== [Dmn-Cons]
 domain (|A, B|)::Rest A::DRest
+
+
+
+
+============ [Vals-Nil]
+values [] []
+
+
+values Rest VRest
+============================== [Vals-Cons]
+values (|A, B|)::Rest B::VRest


### PR DESCRIPTION
The `values` relation is the counterpart to `domain`.  Whereas `domain` gets each first item out of a list of pairs, `values` gets each second item out of a list of pairs.