### PR TITLE
Adding Boolean negation to main

### DIFF
--- a/grammars/sos/core/main/abstractSyntax/Expr.sv
+++ b/grammars/sos/core/main/abstractSyntax/Expr.sv
@@ -345,9 +345,27 @@ top::Expr ::= e1::Expr e2::Expr
                 location=top.location);
   e1.downSubst = top.downSubst;
   e2.downSubst = e1.upSubst;
-  unifyLeft.downSubst = top.downSubst;
+  unifyLeft.downSubst = e2.upSubst;
   unifyRight.downSubst = unifyLeft.upSubst;
   top.upSubst = unifyRight.upSubst;
+}
+
+
+abstract production notExpr
+top::Expr ::= e::Expr
+{
+  top.pp = "!(" ++ e.pp ++ ")";
+
+  top.type = boolType(location=top.location);
+
+  e.downVarTypes = top.downVarTypes;
+
+  local unify::TypeUnify =
+      typeUnify(e.type, boolType(location=top.location),
+                location=top.location);
+  e.downSubst = top.downSubst;
+  unify.downSubst = e.upSubst;
+  top.upSubst = unify.upSubst;
 }
 
 

--- a/grammars/sos/core/main/concreteSyntax/Concrete.sv
+++ b/grammars/sos/core/main/concreteSyntax/Concrete.sv
@@ -70,6 +70,8 @@ closed nonterminal AddExpr_c layout {Spacing_t, Comment_t, Newline_t}
    with ast<Expr>, location;
 closed nonterminal MultExpr_c layout {Spacing_t, Comment_t, Newline_t}
    with ast<Expr>, location;
+closed nonterminal NotExpr_c layout {Spacing_t, Comment_t, Newline_t}
+   with ast<Expr>, location;
 closed nonterminal IOExpr_c layout {Spacing_t, Comment_t, Newline_t}
    with ast<Expr>, location;
 closed nonterminal IndexExpr_c layout {Spacing_t, Comment_t, Newline_t}
@@ -132,12 +134,18 @@ concrete productions top::AddExpr_c
   { top.ast = e.ast; }
 
 concrete productions top::MultExpr_c
-| e1::MultExpr_c '*' e2::FactorExpr_c
+| e1::MultExpr_c '*' e2::NotExpr_c
   { top.ast = multExpr(e1.ast, e2.ast, location=top.location); }
-| e1::MultExpr_c '/' e2::FactorExpr_c
+| e1::MultExpr_c '/' e2::NotExpr_c
   { top.ast = divExpr(e1.ast, e2.ast, location=top.location); }
-| e1::MultExpr_c '%' e2::FactorExpr_c
+| e1::MultExpr_c '%' e2::NotExpr_c
   { top.ast = modExpr(e1.ast, e2.ast, location=top.location); }
+| e::NotExpr_c
+  { top.ast = e.ast; }
+
+concrete productions top::NotExpr_c
+| '!' e::NotExpr_c
+  { top.ast = notExpr(e.ast, location=top.location); }
 | e::IOExpr_c
   { top.ast = e.ast; }
 

--- a/grammars/sos/core/main/concreteSyntax/Terminals.sv
+++ b/grammars/sos/core/main/concreteSyntax/Terminals.sv
@@ -37,6 +37,7 @@ terminal Assign_t   ':=';
 
 terminal Or_t    '||';
 terminal And_t   '&&';
+terminal Not_t   '!';
 
 terminal Bool_t    'bool'    lexer classes {KEYWORD};
 terminal True_t    'true'    lexer classes {KEYWORD};

--- a/stdLib/lists.sos
+++ b/stdLib/lists.sos
@@ -28,6 +28,9 @@ Fixed Judgment domain : [(A, B)] [A]
 /*Values of a pair list (second element of each pair)*/
 Fixed Judgment values : [(A, B)] [B]
 
+/*Combine two lists into a list of pairs*/
+Fixed Judgment zip : [A] [B] [(A, B)]
+
 
 
 /*
@@ -111,3 +114,14 @@ values [] []
 values Rest VRest
 ============================ [Vals-Cons]
 values (A, B)::Rest B::VRest
+
+
+
+
+============ [Zip-Nil]
+zip [] [] []
+
+
+zip ARest BRest Rest
+================================== [Zip-Cons]
+zip A::ARest B::BRest (A, B)::Rest


### PR DESCRIPTION
This adds Boolean negation, written `!<expr>`, to the language for writing functions in the main portion of the language.