### PR TITLE
Fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ documentation](docs/extensibleLanguages.md).
 
 
 ## Required Software and Set-up
-SOS-Ext is written in [Silver](github.com/melt-umn/silver) and
+SOS-Ext is written in [Silver](https://github.com/melt-umn/silver) and
 thus requires Silver for building.  Running SOS-Ext requires Java 8
 and Bash.  Some extensions will require other software to use to run
 the compiled version of the defined language.

--- a/docs/extensibleLanguages.md
+++ b/docs/extensibleLanguages.md
@@ -1,8 +1,8 @@
 # Extensible Languages
-The view of extensible languages on which SOS-Ext is one in which the
-language's syntax and semantics are given by a base language, or host
-language, and a set of independently-developed extensions adding to
-its definitions.
+The view of extensible languages on which SOS-Ext is based is one in
+which the language's syntax and semantics are given by a base
+language, or host language, and a set of independently-developed
+extensions adding to its definitions.
 
 
 ## Basic Extensible Languages
@@ -32,7 +32,7 @@ adds a new semantic relation, do we define it on the new syntax
 constructors introduced by another extension?  This is part of Phil
 Wadler's famous *expression problem*.  One option is to say the
 relation is not derivable on the new constructors.  However, this
-would the combination of new syntax and new semantic relations
+would make the combination of new syntax and new semantic relations
 unusable in practice, since a new static safety check, for example,
 would never hold if a program included new syntax from a different
 extension.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -42,7 +42,7 @@ module builds on the [standard library](stdLib.md).
 
 
 ## Qualified Names
-Each declaration in a grammar is written using a short name, but also
+Each declaration in a module is written using a short name, but also
 has a full, qualified name.  For example, we might define a syntactic
 category named `term` in a module `lang:host`.  While we can use the
 name `term` to refer to this category, its full name is qualified by


### PR DESCRIPTION
I found a few documentation typos, including bad links and incorrect words.  This fixes them.