### PR TITLE
Miscellaneous bug fixes

### DIFF
--- a/grammars/sos/core/modules/Module.sv
+++ b/grammars/sos/core/modules/Module.sv
@@ -136,35 +136,35 @@ top::ModuleList ::= m::Module rest::ModuleList
   --In that case, m would see everything from C twice.
   --We want to keep any multiple copies of m's defs, though, so we can
   --detect multiple declarations of the same name.
-  local tys::[TypeEnvItem] =
+  production tys::[TypeEnvItem] =
         nubBy(\ t1::TypeEnvItem t2::TypeEnvItem -> t1.name == t2.name,
            lookupAllModules(fullBuildsOnDecls, rest.moduleTyDecls)) ++
            m.tyDecls;
-  local cons::[ConstructorEnvItem] =
+  production cons::[ConstructorEnvItem] =
         nubBy(\ c1::ConstructorEnvItem c2::ConstructorEnvItem ->
                 c1.name == c2.name,
            lookupAllModules(fullBuildsOnDecls,
               rest.moduleConstructorDecls)) ++ m.constructorDecls;
-  local jdgs::[JudgmentEnvItem] =
+  production jdgs::[JudgmentEnvItem] =
         nubBy(\ j1::JudgmentEnvItem j2::JudgmentEnvItem ->
                 j1.name == j2.name,
            lookupAllModules(fullBuildsOnDecls,
               rest.moduleJudgmentDecls)) ++ m.judgmentDecls;
-  local trns::[TranslationEnvItem] =
+  production trns::[TranslationEnvItem] =
         nubBy(\ t1::TranslationEnvItem t2::TranslationEnvItem ->
                 t1.name == t2.name,
            lookupAllModules(fullBuildsOnDecls,
               rest.moduleTranslationDecls)) ++ m.translationDecls;
-  local rules::[RuleEnvItem] =
+  production rules::[RuleEnvItem] =
         nubBy(\ r1::RuleEnvItem r2::RuleEnvItem -> r1.name == r2.name,
            lookupAllModules(fullBuildsOnDecls,
               rest.moduleRuleDecls)) ++ m.ruleDecls;
-  local concretes::[ConcreteEnvItem] =
+  production concretes::[ConcreteEnvItem] =
         nubBy(\ c1::ConcreteEnvItem c2::ConcreteEnvItem ->
                 c1.name == c2.name,
            lookupAllModules(fullBuildsOnDecls,
               rest.moduleConcreteDecls)) ++ m.concreteDecls;
-  local functions::[FunctionEnvItem] =
+  production functions::[FunctionEnvItem] =
         nubBy(\ f1::FunctionEnvItem f2::FunctionEnvItem ->
                 f1.name == f2.name,
            lookupAllModules(fullBuildsOnDecls,

--- a/grammars/sos/core/semanticDefs/concreteSyntax/Concrete.sv
+++ b/grammars/sos/core/semanticDefs/concreteSyntax/Concrete.sv
@@ -22,6 +22,14 @@ concrete productions top::DeclList_c
   { top.ast = nilDecls(location=top.location); }
 | d::TopDecl_c x::EmptyNewlines rest::DeclList_c
   { top.ast = branchDecls(d.ast, rest.ast, location=top.location); }
+  {-We pull this out here so we can have EmptyNewlines between entries
+    in a syntax declaration, adding the EmptyNewlines that can go
+    between different top-level declarations to the syntax declaration
+    concrete production itself.-}
+| decl::AbsSyntaxDecl_c rest::DeclList_c
+  { top.ast = branchDecls(absSyntaxDecls(decl.ast,
+                                         location=decl.location),
+                          rest.ast, location=top.location); }
 
 
 
@@ -37,8 +45,6 @@ concrete productions top::TopDecl_c
                             location=top.location); }
 | r::Rule_c
   { top.ast = ruleDecls(r.ast, location=top.location); }
-| decl::AbsSyntaxDecl_c
-  { top.ast = absSyntaxDecls(decl.ast, location=top.location); }
 | decl::JudgmentDecl_c
   { top.ast = judgmentDecls(decl.ast, location=top.location); }
 
@@ -139,16 +145,12 @@ closed nonterminal AbsConstructorDecls_c layout {Spacing_t, Comment_t}
    with ast<AbsConstructorDecls>, location;
 
 concrete productions top::AbsConstructorDecls_c
-| d::AbsConstructorDecl_c Newline_t
+| d::AbsConstructorDecl_c Newline_t x::EmptyNewlines
   { top.ast = d.ast; }
-| d::AbsConstructorDecl_c '|' rest::AbsConstructorDecls_c
+| d::AbsConstructorDecl_c x::EmptyNewlines
+  '|' rest::AbsConstructorDecls_c
   { top.ast = branchAbsConstructorDecls(d.ast, rest.ast,
                                         location=top.location); }
-| d::AbsConstructorDecl_c Newline_t '|' rest::AbsConstructorDecls_c
-  { top.ast = branchAbsConstructorDecls(d.ast, rest.ast,
-                                        location=top.location); }
-| Newline_t rest::AbsConstructorDecls_c
-  { top.ast = rest.ast; }
 
 
 

--- a/grammars/sos/translation/semantic/extensibella/Extensibella.sv
+++ b/grammars/sos/translation/semantic/extensibella/Extensibella.sv
@@ -123,7 +123,20 @@ top::Metaterm ::= rel::String args::[ExtensibellaTerm]
                   args));
 
   top.vars = unions(map((.vars), args));
-  top.usedRels = [rel];
+  --is_list and is_pair get the sub-relations added to the rel string,
+  --so split the relation to find all the relations
+  local parseRels::([String] ::= String) =
+      \ s::String ->
+        if startsWith("(", s)
+        then --remove () and try again
+             parseRels(substring(1, length(s) - 1, s))
+        else case explode(" ", s) of
+             | [] -> error("Impossible") --must be at least one
+             | [r] -> [r] --simply one relation
+             | r::tl -> --get rels from all sub-rels
+               r::flatMap(parseRels, tl)
+             end;
+  top.usedRels = parseRels(rel);
   top.definedRel = rel;
 
   top.replaced =

--- a/grammars/sos/translation/semantic/extensibella/Module.sv
+++ b/grammars/sos/translation/semantic/extensibella/Module.sv
@@ -106,7 +106,15 @@ top::ModuleList ::= m::Module rest::ModuleList
   --rules for imported relations so they hold on unknown constructors
   local rulesImportedUnknown::[Def] =
       buildImportedUnknownRules(importedJdgs, importedTys,
-                                m.judgmentEnv);
+                                m.judgmentEnv) ++
+      --rules for unknown constructors for imported types
+      flatMap(\ t::TypeEnvItem ->
+                if sameModule(toQName(m.modName, bogusLoc()), t.name)
+                then []
+                else [factDef(relationMetaterm(t.name.ebIsName,
+                                 [nameExtensibellaTerm(
+                                     t.name.ebUnknownName)]))],
+              tys);
   --rules for translation rules holding on unknown constructors
   local constrEnvs::[ConstructorEnvItem] =
       map(\ t::TypeEnvItem ->

--- a/stdLib/stdLib.xthm
+++ b/stdLib/stdLib.xthm
@@ -50,7 +50,7 @@ induction on 1. intros LkpA LkpB. LkpA: case LkpA.
       apply IH to LkpA1 LkpB1. search.
 
 
-Theorem lookup_member [Key, Value] :
+Theorem lookup_mem [Key, Value] :
   forall L (Key : Key) (Value : Value),
     lookup L Key Value -> mem (Key, Value) L.
 induction on 1. intros Lkp'. Lkp: case Lkp'.
@@ -58,6 +58,20 @@ induction on 1. intros Lkp'. Lkp: case Lkp'.
    search.
   %2:  Lkp-Later
    apply IH to Lkp1. search.
+
+
+Theorem no_lookup_mem [Key, Value] :
+  forall L (Key : Key) (Value : Value),
+    no_lookup L Key -> mem (Key, Value) L -> false.
+induction on 1. intros Lkp Mem. Lkp: case Lkp.
+  %1:  NLkp-Nil
+   case Mem.
+  %2:  NLkp-Cons
+   Mem: case Mem.
+     %2.1:  Mem-Here
+      apply Lkp to _.
+     %2.2:  Mem-Later
+      apply IH to Lkp1 Mem.
 
 
 Theorem lookup_select [Key, Value] :
@@ -68,6 +82,39 @@ induction on 1. intros Lkp'. Lkp: case Lkp'.
    search.
   %2:  Lkp-Later
    apply IH to Lkp1. search.
+
+
+Theorem no_lookup_select [Key, Value] :
+  forall L (Key : Key) (Value : Value) R,
+    no_lookup L Key -> select (Key, Value) R L -> false.
+induction on 1. intros NLkp Slct. NLkp: case NLkp.
+  %1:  NLkp-Nil
+   case Slct.
+  %2:  NLkp-Cons
+   Slct: case Slct.
+     %2.1:  Slct-First
+      apply NLkp to _.
+     %2.2:  Slct-Later
+      apply IH to NLkp1 Slct.
+
+
+Theorem select_lookup [Key, Value] :
+  forall L (Key K : Key) (Value V : Value) R,
+    lookup L K V -> select (Key, Value) R L -> (K = Key -> false) ->
+    lookup R K V.
+induction on 1. intros Lkp Slct NEq. Lkp: case Lkp.
+  %1:  Lkp-Here
+   Slct: case Slct.
+     %1.1:  Slct-First
+      apply NEq to _.
+     %1.2:  Slct-Later
+      search.
+  %2:  Lkp-Later
+   Slct: case Slct.
+     %2.1:  Slct-First
+      search.
+     %2.2:  Slct-Later
+      apply IH to Lkp1 Slct _. search.
 
 
 Theorem mem_select [Item] : forall L (X : Item),
@@ -86,6 +133,19 @@ induction on 1. intros Slct'. Slct: case Slct'.
    search.
   %2:  Slct-Later
    apply IH to Slct. search.
+
+
+Theorem mem_after_select_before [Item] : forall L L' (X Y : Item),
+  select X L' L -> mem Y L' -> mem Y L.
+induction on 1. intros Slct Mem. Slct: case Slct.
+  %1:  Slct-First
+   search.
+  %2:  Slct-Later
+   Mem: case Mem.
+     %2.1:  Mem-Here
+      search.
+     %2.2:  Mem-Later
+      apply IH to Slct Mem. search.
 
 
 Theorem mem_append_left [A] : forall L1 L2 L (A : A),


### PR DESCRIPTION
This is a set of fixes to a few bugs I found while working on an Extensibella example:
* The concrete syntax for declaring abstract syntax did not allow arbitrary blank lines between constructor declarations, so comment lines could not be inserted.
* The Extensibella translation did not correctly identify relations depending on other relations when it was through a relation as an argument (e.g. `is_list is_integer` would not identify the clause as using `is_integer`), thus generating invalid Abella code where a relation was not defined until after it was used.
* The standard library was missing some useful theorems, and one had an inappropriate name.