### PR TITLE
Fix Extensibella is relation rules for unknown constructors

### DIFF
--- a/examples/sec_SOS/host_thms.xthm
+++ b/examples/sec_SOS/host_thms.xthm
@@ -545,7 +545,7 @@ Theorem vars_equiv_left :
     D1 ++ D2 = D ->
     (forall X U1 U2, mem X D1 -> lookup G1 X U1 ->
                      lookup G2 X U2 -> U1 = U2).
-intros Equiv J Mem Lkp1 Lkp2. backchain Equiv.
+intros Equiv J Mem Lkp1 Lkp2. backchain Equiv with X = X.
 backchain mem_append_left.
 Theorem vars_equiv_right :
   forall (G1 : list (pair string value)) G2 D D1 D2,
@@ -554,7 +554,7 @@ Theorem vars_equiv_right :
     D1 ++ D2 = D ->
     (forall X U1 U2, mem X D2 -> lookup G1 X U1 ->
                      lookup G2 X U2 -> U1 = U2).
-intros Equiv J Mem Lkp1 Lkp2. backchain Equiv.
+intros Equiv J Mem Lkp1 Lkp2. backchain Equiv with X = X.
 backchain mem_append_right.
 
 

--- a/examples/sec_SOS/security_thms.xthm
+++ b/examples/sec_SOS/security_thms.xthm
@@ -647,12 +647,12 @@ Extensible_Theorem
       intros Lkp. apply stmt_public_branch to Sec2 EvA2 Lkp. search.
     apply public_equiv_swap to LkpEq EqGA'GB'. search.
    %EvB by E-IfThenElseFalse
-    assert S = public -> false.
+    NEq: assert S = public -> false.
       intros Eq. case Eq. apply level_not_public to Is _ _ EvA1 EvB _.
     EqGAGA': apply stmt_not_public_no_public_change to Sec2 _ EvA2.
-      apply join_public to Sec1. search.
+      intros E. case E. apply join_public to Sec1. backchain NEq.
     EqGBGB': apply stmt_not_public_no_public_change to Sec3 _ EvB1.
-      apply join_public to Sec1. search.
+      intros E. case E. apply join_public to Sec1.  backchain NEq.
     EqGAGB': apply public_equiv_trans to Rel EqGBGB'.
     EqGA'GA: apply public_equiv_symm to EqGAGA'.
     EqGA'GB: apply public_equiv_trans to EqGA'GA Rel.
@@ -660,12 +660,12 @@ Extensible_Theorem
 %E-IfThenElseFalse
  Is: case Is. Sec: case Sec. EvB: case EvB.
    %EvB by E-IfThenElseTrue
-    assert S = public -> false.
+    NEq: assert S = public -> false.
       intros Eq. case Eq. apply level_not_public to Is _ _ EvA1 EvB _.
     EqGAGA': apply stmt_not_public_no_public_change to Sec3 _ EvA2.
-      apply join_public to Sec1. search.
+      intros E. case E. apply join_public to Sec1. backchain NEq.
     EqGBGB': apply stmt_not_public_no_public_change to Sec2 _ EvB1.
-      apply join_public to Sec1. search.
+      intros E. case E. apply join_public to Sec1. backchain NEq.
     EqGAGB': apply public_equiv_trans to Rel EqGBGB'.
     EqGA'GA: apply public_equiv_symm to EqGAGA'.
     EqGA'GB: apply public_equiv_trans to EqGA'GA Rel.

--- a/grammars/sos/translation/semantic/extensibella/Module.sv
+++ b/grammars/sos/translation/semantic/extensibella/Module.sv
@@ -111,9 +111,9 @@ top::ModuleList ::= m::Module rest::ModuleList
       flatMap(\ t::TypeEnvItem ->
                 if sameModule(toQName(m.modName, bogusLoc()), t.name)
                 then []
-                else [factDef(relationMetaterm(t.name.ebIsName,
-                                 [nameExtensibellaTerm(
-                                     t.name.ebUnknownName)]))],
+                else [buildOneUnknownRule(t.name.ebIsName,
+                         [nameType(t.name, location=bogusLoc())],
+                         0, t)],
               tys);
   --rules for translation rules holding on unknown constructors
   local constrEnvs::[ConstructorEnvItem] =


### PR DESCRIPTION
Extensibella rules for the unknown constructor for is relations should have the same form as rules for the unknown constructor for other relations.  This fixes the discrepancy.

It also fixes some failing Extensibella proofs.  It appears these might have been failing due to an Abella update.