### PR TITLE
Extensibella non extensible compile

### DIFF
--- a/grammars/sos/translation/semantic/extensibella/Module.sv
+++ b/grammars/sos/translation/semantic/extensibella/Module.sv
@@ -7,11 +7,13 @@ import sos:core:main:abstractSyntax only MainFile;
 attribute
    ebKinds, ebConstrs, ebRulesByModule, ebJudgments,
    ebTranslationRules, ebErrors,
-   defFileContents, interfaceFileContents
+   defFileContents, interfaceFileContents, fullFileContents
 occurs on ModuleList;
 
 synthesized attribute defFileContents::String;
 synthesized attribute interfaceFileContents::String;
+--definition for the non-extensible version of the language
+synthesized attribute fullFileContents::String;
 
 aspect production stdLibModuleList
 top::ModuleList ::= files::Files
@@ -59,6 +61,9 @@ top::ModuleList ::= files::Files
          top.ebJudgments, top.ebRulesByModule, []);
   top.interfaceFileContents =
       buildExtensibellaInterfaceFile(stdLibName, [(stdLibName, [])]);
+  top.fullFileContents =
+      buildExtensibellaFile(top.ebKinds, top.ebConstrs,
+         top.ebJudgments, top.ebRulesByModule, []);
 
   top.ebErrors = [];
 }
@@ -140,6 +145,13 @@ top::ModuleList ::= m::Module rest::ModuleList
   top.interfaceFileContents =
       buildExtensibellaInterfaceFile(m.modName,
          (stdLibName, [])::top.buildsOns);
+  top.fullFileContents =
+      buildExtensibellaFile(top.ebKinds,
+         --no unknown constructors in the non-extensible definition
+         top.ebConstrs,
+         top.ebJudgments, top.ebRulesByModule,
+         --no unknown rules in the non-extensible definition
+         []);
 
   top.ebErrors =
       case intersect(map((.name), m.constructorDecls),

--- a/stdLib/lists.sos
+++ b/stdLib/lists.sos
@@ -13,6 +13,9 @@ Fixed Judgment no_lookup : [(Key, Item)] Key
 /*Holds if the item is in the list*/
 Fixed Judgment mem : Item [Item]
 
+/*Holds if the item is NOT in the list*/
+Fixed Judgment not_mem : Item [Item]
+
 /*Splits the list into the item plus the rest of the list around it:
   select A Rest L*/
 Fixed Judgment select : Item [Item] [Item]
@@ -78,6 +81,18 @@ mem Item Item::Rest
 mem Item Rest
 ================ [Mem-Later]
 mem Item I::Rest
+
+
+
+
+=============== [NMem-Nil]
+not_mem Item []
+
+
+I != Item
+not_mem Item Rest
+==================== [NMem-Cons]
+not_mem Item I::Rest
 
 
 

--- a/stdLib/stdLib.xthm
+++ b/stdLib/stdLib.xthm
@@ -263,6 +263,60 @@ induction on 1. intros Mem' App'. Mem: case Mem'.
       Or: apply IH to Mem App. case Or. search. search.
 
 
+Theorem not_mem [A] : forall (A : A) L,
+  not_mem A L -> mem A L -> false.
+induction on 1. intros N M. N: case N.
+  %1:  NMem-Nil
+   case M.
+  %2:  NMem-Cons
+   M: case M.
+     %2.1:  Mem-Here
+      apply N to _.
+     %2.2:  Mem-Later
+      apply IH to N1 M.
+
+
+Theorem not_mem_select [A] : forall L (A : A) L',
+  not_mem A L -> select A L' L -> false.
+intros N S. M: apply select_mem to S. apply not_mem to N M.
+
+
+Theorem not_mem_after_select_before [A] : forall L L' (X Y : A),
+  select X L' L -> not_mem Y L' -> (X = Y -> false) -> not_mem Y L.
+induction on 1. intros S N NEq. S: case S.
+  %1:  Slct-First
+   search.
+  %2:  Slct-Later
+   case N. apply IH to S _ _. search.
+
+
+Theorem not_mem_before_select_after [A] : forall L L' (X Y : A),
+  select X L' L -> not_mem Y L -> not_mem Y L'.
+induction on 1. intros S N. S: case S.
+  %1:  Slct-First
+   case N. search.
+  %2:  Slct-Later
+   case N. apply IH to S _. search.
+
+
+Theorem not_mem_append [A] : forall L1 L2 L (A : A),
+  not_mem A L1 -> not_mem A L2 -> L1 ++ L2 = L -> not_mem A L.
+induction on 1. intros NA NB App. NA: case NA.
+  %1:  NMem-Nil
+   case App. search.
+  %2:  NMem-Cons
+   case App. apply IH to NA1 _ _. search.
+
+
+Theorem not_mem_append_back [A] : forall L1 L2 L (A : A),
+  not_mem A L -> L1 ++ L2 = L -> not_mem A L1 /\ not_mem A L2.
+induction on 2. intros N App.  App: case App.
+  %1:  [] ++ L2 = L2
+   search.
+  %2:  (H::T) ++ L2 = H::L4
+   case N. apply IH to _ App. search.
+
+
 Theorem permutation_mem [Item] : forall (L M : list Item) I,
   permutation L M -> mem I L -> mem I M.
 induction on 2. intros P M. M: case M.


### PR DESCRIPTION
For Extensibella proof composition, we need a version of the Extensibella definition file for a language without the constructors and rules for the stand-in generic constructor.  This makes it possible to output such a file.